### PR TITLE
Updated testnet deets

### DIFF
--- a/pages/block-explorers.mdx
+++ b/pages/block-explorers.mdx
@@ -7,11 +7,12 @@
 | Network       | Supported |   Link |
 | :------------ | :---------: | ----------: |
 | Mainnet    |    ✅   |    https://apescan.io/ |
-| Curtis Testnet    |   ✅  |   https://apescan.io/ |
+| Curtis Testnet    |   ✅  |   https://curtis.apescan.io/ |
 
 
 [ApeScan](https://apescan.io/), powered by [Etherscan](https://etherscan.io/) is the primary block explorer for ApeChain. It allowing users to track transactions, view wallets, and interact with smart contracts. It simplifies monitoring ApeCoin activities and supports developers with tools for contract verification and dApp interaction​s.
 
+Note: ApeScan **DOES NOT SUPPORT** NFT metadata and images on Curtis Testnet yet.
 
 ## Blockscout
 


### PR DESCRIPTION
Fixed link to Testnet and added a note: ApeScan, powered by Etherscan does not support NFT metadata and images.