### PR TITLE
Add Envio to Subgraphs page

### DIFF
--- a/pages/subgraphs.mdx
+++ b/pages/subgraphs.mdx
@@ -1,5 +1,83 @@
 import { Callout } from 'nextra/components'
 
+## Goldsky
+​
+Goldsky is ApeChain's trusted partner for high-performance data indexing and streaming, making it easy for developers to power dApps, analytics, and AI agents with fast, reliable access to ApeChain's on-chain data.
+
+Goldsky offers **two powerful products**:
+
+### Subgraphs
+
+[Subgraphs](https://docs.goldsky.com/subgraphs/deploying-subgraphs) allow you to index ApeChain data into a highly optimized format for **instant, flexible querying**.
+
+Use subgraphs when you want to **read and display on-chain data** inside apps, websites, dashboards, bots, and more.
+
+- **Ultra-fast reads**: Query large volumes of on-chain data with millisecond response times.
+- **Flexible GraphQL APIs**: Filter, paginate, and fetch exactly the data you need.
+- **Custom indexing logic**: Handle complex event processing, join entities, build derived fields.
+- **Auto-scaling**: Goldsky automatically scales infrastructure for you, no more worrying about node ops.
+- **Instant Deployment**: Create subgraphs instantly by uploading your ABI and contract address, no GraphQL coding required (but you can fully customize if you want).
+
+🛠️ **Example Use Cases**:
+
+- NFT marketplaces (fetching listings, offers, metadata)
+- DeFi dashboards (tracking TVL, trades, positions)
+- Social apps (aggregating profiles, posts, on-chain actions)
+- In-game marketplaces (real-time item trades and player stats)
+
+### Turbo
+
+[Turbo](https://docs.goldsky.com/turbo-pipelines/introduction) is a real-time data streaming pipeline that **replicates ApeChain data into your own database**, letting you power complex backends, machine learning, or data analytics.
+
+- **Real-time streaming**: Ingest new blocks, events, transactions as they happen.
+- **Your schema, your rules**: Turbo supports flexible transformations and customizations.
+- **Database integration**: Push to Postgres, Clickhouse, or your warehouse of choice.
+- **Perfect for AI/ML**: Build embeddings, train models, and run inference on live blockchain data.
+
+🛠️ **Example Use Cases**:
+
+- Powering AI agents with up-to-the-second on-chain awareness
+- Building custom analytics dashboards
+- Enabling real-time alerts and risk monitoring systems
+- Aggregating on-chain activity into internal data lakes
+
+## Why Goldsky for ApeChain Builders?
+
+- Lightning-fast query speeds
+- Real-time data pipelines
+- No need to manage indexers or infra
+- Instant onboarding with minimal config
+- Trusted by major Web3 projects across DeFi, gaming, AI, and social
+
+| Network | Subgraphs | Turbo |
+| --- | --- | --- |
+| Mainnet | ✅ | ✅ |
+| Curtis | ✅ | ✅ |
+
+### How to Get Started
+
+Goldsky makes it fast and easy to launch a subgraph or pipeline:
+
+- **Deploy via CLI**: Create fully custom subgraphs or Turbo configs from your local setup.
+- **Instant deployment**: Just upload your contract ABI + address, and Goldsky generates a working subgraph for you in minutes, no GraphQL coding needed.
+- **Leverage AI skills**: Deploy, debug, and even query Turbo pipelines using your favorite AI coding assistants with AI agent skills.
+
+### Demo: Intro to Indexing with Goldsky
+
+<iframe src="https://drive.google.com/file/d/1Z0yWzi9tZsJOUKoxjhO5Fk1xdI1LWo_N/preview" width="720" height="480" allow="autoplay" style={{paddingTop: '20px'}}></iframe>
+
+👉 [**Follow the full step-by-step guide here**](https://docs.goldsky.com/chains/apechain?utm_source=apechain&utm_medium=docs) to deploy on ApeChain.
+
+If you need help designing your schema or choosing between Subgraphs and Turbo, [**reach out to the Goldsky team**](https://docs.goldsky.com/getting-support) — they're happy to guide you.
+
+### Demo: Intro to Turbo Pipelines
+
+<iframe src="https://drive.google.com/file/d/1b2aCQlHvxeJm4md6SqPikRi0gw6DaSp2/preview" width="720" height="480" allow="autoplay" style={{paddingTop: '20px'}}></iframe>
+
+Turbo pipelines are Goldsky’s next generation data pipeline engine, offering significant performance improvements and new capabilities, including inter-batch parallelism and startups under 5 seconds.
+
+👉 [**Learn more about Turbo Pipelines**](https://docs.goldsky.com/turbo-pipelines/introduction) in the Goldsky docs.
+
 ## Envio
 
 [Envio](https://envio.dev/?utm_source=apechain&utm_medium=docs) is a high-performance indexing framework that **natively supports any EVM chain out of the box**, including ApeChain. It gives developers real-time and historical access to ApeChain's on-chain data through a single GraphQL API, with a fully managed hosting option.
@@ -85,84 +163,6 @@ See the [RPC data source guide](https://docs.envio.dev/docs/HyperIndex/rpc-sync?
 If you need help setting up your indexer, [reach out to the Envio team](https://discord.gg/envio) on Discord, where they are always happy to help.
 
 [Website](https://envio.dev/?utm_source=apechain&utm_medium=docs) | [Docs](https://docs.envio.dev/?utm_source=apechain&utm_medium=docs) | [Supported Networks](https://docs.envio.dev/docs/HyperIndex/supported-networks?utm_source=apechain&utm_medium=docs) | [Discord](https://discord.gg/envio) | [X](https://twitter.com/envio_indexer) | [GitHub](https://github.com/enviodev)
-
-## Goldsky
-​
-Goldsky is ApeChain's trusted partner for high-performance data indexing and streaming, making it easy for developers to power dApps, analytics, and AI agents with fast, reliable access to ApeChain's on-chain data.
-
-Goldsky offers **two powerful products**:
-
-### Subgraphs
-
-[Subgraphs](https://docs.goldsky.com/subgraphs/deploying-subgraphs) allow you to index ApeChain data into a highly optimized format for **instant, flexible querying**.
-
-Use subgraphs when you want to **read and display on-chain data** inside apps, websites, dashboards, bots, and more.
-
-- **Ultra-fast reads**: Query large volumes of on-chain data with millisecond response times.
-- **Flexible GraphQL APIs**: Filter, paginate, and fetch exactly the data you need.
-- **Custom indexing logic**: Handle complex event processing, join entities, build derived fields.
-- **Auto-scaling**: Goldsky automatically scales infrastructure for you, no more worrying about node ops.
-- **Instant Deployment**: Create subgraphs instantly by uploading your ABI and contract address, no GraphQL coding required (but you can fully customize if you want).
-
-🛠️ **Example Use Cases**:
-
-- NFT marketplaces (fetching listings, offers, metadata)
-- DeFi dashboards (tracking TVL, trades, positions)
-- Social apps (aggregating profiles, posts, on-chain actions)
-- In-game marketplaces (real-time item trades and player stats)
-
-### Turbo
-
-[Turbo](https://docs.goldsky.com/turbo-pipelines/introduction) is a real-time data streaming pipeline that **replicates ApeChain data into your own database**, letting you power complex backends, machine learning, or data analytics.
-
-- **Real-time streaming**: Ingest new blocks, events, transactions as they happen.
-- **Your schema, your rules**: Turbo supports flexible transformations and customizations.
-- **Database integration**: Push to Postgres, Clickhouse, or your warehouse of choice.
-- **Perfect for AI/ML**: Build embeddings, train models, and run inference on live blockchain data.
-
-🛠️ **Example Use Cases**:
-
-- Powering AI agents with up-to-the-second on-chain awareness
-- Building custom analytics dashboards
-- Enabling real-time alerts and risk monitoring systems
-- Aggregating on-chain activity into internal data lakes
-
-## Why Goldsky for ApeChain Builders?
-
-- Lightning-fast query speeds
-- Real-time data pipelines
-- No need to manage indexers or infra
-- Instant onboarding with minimal config
-- Trusted by major Web3 projects across DeFi, gaming, AI, and social
-
-| Network | Subgraphs | Turbo |
-| --- | --- | --- |
-| Mainnet | ✅ | ✅ |
-| Curtis | ✅ | ✅ |
-
-### How to Get Started
-
-Goldsky makes it fast and easy to launch a subgraph or pipeline:
-
-- **Deploy via CLI**: Create fully custom subgraphs or Turbo configs from your local setup.
-- **Instant deployment**: Just upload your contract ABI + address, and Goldsky generates a working subgraph for you in minutes, no GraphQL coding needed.
-- **Leverage AI skills**: Deploy, debug, and even query Turbo pipelines using your favorite AI coding assistants with AI agent skills.
-
-### Demo: Intro to Indexing with Goldsky
-
-<iframe src="https://drive.google.com/file/d/1Z0yWzi9tZsJOUKoxjhO5Fk1xdI1LWo_N/preview" width="720" height="480" allow="autoplay" style={{paddingTop: '20px'}}></iframe>
-
-👉 [**Follow the full step-by-step guide here**](https://docs.goldsky.com/chains/apechain?utm_source=apechain&utm_medium=docs) to deploy on ApeChain.
-
-If you need help designing your schema or choosing between Subgraphs and Turbo, [**reach out to the Goldsky team**](https://docs.goldsky.com/getting-support) — they're happy to guide you.
-
-### Demo: Intro to Turbo Pipelines
-
-<iframe src="https://drive.google.com/file/d/1b2aCQlHvxeJm4md6SqPikRi0gw6DaSp2/preview" width="720" height="480" allow="autoplay" style={{paddingTop: '20px'}}></iframe>
-
-Turbo pipelines are Goldsky’s next generation data pipeline engine, offering significant performance improvements and new capabilities, including inter-batch parallelism and startups under 5 seconds.
-
-👉 [**Learn more about Turbo Pipelines**](https://docs.goldsky.com/turbo-pipelines/introduction) in the Goldsky docs.
 
 ## Ormi 
 

--- a/pages/subgraphs.mdx
+++ b/pages/subgraphs.mdx
@@ -1,5 +1,91 @@
 import { Callout } from 'nextra/components'
 
+## Envio
+
+[Envio](https://envio.dev/?utm_source=apechain&utm_medium=docs) is a high-performance indexing framework that **natively supports any EVM chain out of the box**, including ApeChain. It gives developers real-time and historical access to ApeChain's on-chain data through a single GraphQL API, with a fully managed hosting option.
+
+Envio offers a **complete toolkit** for indexing and accessing ApeChain data:
+
+### HyperIndex
+
+[HyperIndex](https://docs.envio.dev/docs/HyperIndex/overview?utm_source=apechain&utm_medium=docs) is Envio's full-featured indexing framework that turns your ApeChain smart contract events into a highly optimized, queryable GraphQL API.
+
+Use HyperIndex when you want to **read and display on-chain data** inside apps, websites, dashboards, bots, and more.
+
+- **Any EVM out of the box**: Index ApeChain natively using your own RPC as the data source, no waiting for dedicated support.
+- **Flexible GraphQL APIs**: Filter, paginate, and fetch exactly the data you need.
+- **Automatic code generation**: Generate a working indexer from any verified contract address with `pnpx envio init`.
+- **Flexible language support**: Write event handlers in TypeScript, JavaScript, or ReScript.
+- **Reorg support**: Gracefully handles chain reorganisations without sacrificing latency.
+- **Managed or self-hosted**: Deploy on Envio Cloud, or run your own setup.
+
+🛠️ **Example Use Cases**:
+
+- NFT marketplaces (fetching listings, offers, metadata)
+- DeFi dashboards (tracking TVL, trades, positions)
+- Gaming and social apps (player stats, on-chain actions)
+- Real-time analytics and monitoring systems
+
+### HyperSync & HyperRPC
+
+[HyperSync](https://docs.envio.dev/docs/HyperSync/overview?utm_source=apechain&utm_medium=docs) is Envio's high-performance data engine. Where a network is supported on HyperSync, HyperIndex uses it as the default data source for dramatically faster syncs, up to 2000x faster than traditional RPC. [HyperRPC](https://docs.envio.dev/docs/HyperRPC/overview-hyperrpc?utm_source=apechain&utm_medium=docs) is an extremely fast, read-only RPC for data-heavy workloads.
+
+On ApeChain, HyperSync and HyperRPC are available today for the **Curtis testnet**:
+
+- HyperSync: `https://curtis.hypersync.xyz`
+- HyperRPC: `https://curtis.rpc.hypersync.xyz`
+
+## Why Envio for ApeChain Builders?
+
+- Native support for any EVM chain, including ApeChain, out of the box
+- Real-time and historical data through a single GraphQL API
+- Automatic indexer generation from a contract address
+- Managed hosting on Envio Cloud, or self-host your own deployment
+- Multi-chain data aggregation across EVM and non-EVM networks
+
+| Network | Chain ID | HyperIndex | HyperSync / HyperRPC |
+| --- | --- | --- | --- |
+| ApeChain Mainnet | 33139 | ✅ (via RPC data source) | On request via [Discord](https://discord.gg/envio) |
+| Curtis Testnet | 33111 | ✅ | ✅ |
+
+### How to Get Started
+
+1. **Initialise your indexer** and import your ApeChain contract:
+
+```shell
+pnpx envio init
+```
+
+Choose **Contract Import** and provide your verified ApeChain contract address to auto-generate a config, schema, and event handlers. See the [Quickstart](https://docs.envio.dev/docs/HyperIndex/quickstart?utm_source=apechain&utm_medium=docs).
+
+2. **Configure ApeChain** in your `config.yaml` using chain ID `33139` and your ApeChain RPC as the data source:
+
+```yaml
+name: IndexerName # Specify indexer name
+chains:
+  - id: 33139 # ApeChain Mainnet
+    rpc:
+      - url: https://YOUR_APECHAIN_RPC_URL
+        for: sync
+    start_block: START_BLOCK_NUMBER
+    contracts:
+      - name: ContractName
+        address:
+          - "0xYourContractAddress"
+        events:
+          - event: Event
+```
+
+See the [RPC data source guide](https://docs.envio.dev/docs/HyperIndex/rpc-sync?utm_source=apechain&utm_medium=docs) and the [configuration guide](https://docs.envio.dev/docs/HyperIndex/configuration-file?utm_source=apechain&utm_medium=docs) for the full set of options.
+
+3. **Run or deploy**: run your indexer locally with Docker, or deploy it with a git-based workflow on [Envio Cloud](https://docs.envio.dev/docs/HyperIndex/hosted-service-deployment?utm_source=apechain&utm_medium=docs).
+
+4. **Query** your indexed ApeChain data through the GraphQL API.
+
+If you need help setting up your indexer, [reach out to the Envio team](https://discord.gg/envio) on Discord, where they are always happy to help.
+
+[Website](https://envio.dev/?utm_source=apechain&utm_medium=docs) | [Docs](https://docs.envio.dev/?utm_source=apechain&utm_medium=docs) | [Supported Networks](https://docs.envio.dev/docs/HyperIndex/supported-networks?utm_source=apechain&utm_medium=docs) | [Discord](https://discord.gg/envio) | [X](https://twitter.com/envio_indexer) | [GitHub](https://github.com/enviodev)
+
 ## Goldsky
 ​
 Goldsky is ApeChain's trusted partner for high-performance data indexing and streaming, making it easy for developers to power dApps, analytics, and AI agents with fast, reliable access to ApeChain's on-chain data.


### PR DESCRIPTION
This PR adds **Envio** to the Subgraphs page.

**What's included**
- New `## Envio` section at the top of `pages/subgraphs.mdx`, following the same structure as the existing provider entries.
- Covers HyperIndex, HyperSync, HyperRPC, and Envio Cloud, with a network support table and a copy-paste `config.yaml` for ApeChain.

Envio's HyperIndex natively supports indexing any EVM chain out of the box, so builders can index ApeChain mainnet (33139) today using their own RPC as the data source, with a queryable GraphQL API and managed hosting on Envio Cloud. HyperSync and HyperRPC endpoints are also available for the Curtis testnet (33111).

Links: [envio.dev](https://envio.dev) · [docs.envio.dev](https://docs.envio.dev) · [Supported networks](https://docs.envio.dev/docs/HyperIndex/supported-networks)
