### PR TITLE
Add token addresses to mainnet contract information

### DIFF
--- a/pages/contracts/Mainnet/contract-information.mdx
+++ b/pages/contracts/Mainnet/contract-information.mdx
@@ -9,6 +9,14 @@ You can visit the [Hub](https://apechain.hub.caldera.xyz/), where you'll find Ro
 |parentChainId |```42161```|
 |nativeToken |```0x7f9FBf9bDd3F4105C478b996B648FE6e828a1e98```|
 
+### Tokens
+
+| Name | Address | Decimals |
+| :------------ | :---------: | :---------: |
+|WAPE |```0x48b62137edfa95a428d35c09e44256a739f6b557```|18|
+|ApeUSD |```0xA2235d059F80e176D931Ef76b6C51953Eb3fBEf4```|18|
+|ApeETH |```0xcf800f4948d16f23333508191b1b1591daf70438```|18|
+
 ### CoreContracts 
 
 | Name | Address |    


### PR DESCRIPTION
The contracts page documents rollup, bridge and gateway addresses but no tokens, so there is no documented source for the token addresses developers need day to day.

Adds WAPE, ApeUSD and ApeETH with their decimals, in the same table format as the existing sections. All values were read from mainnet via eth_call.

Only native ApeChain tokens are listed. Bridged third-party tokens are left out deliberately, so this page stays a record of the chain's own contracts.