### PR TITLE
Fix four dead documentation links

### DIFF
--- a/pages/cross-chain.mdx
+++ b/pages/cross-chain.mdx
@@ -57,6 +57,6 @@ Espresso guarantees that all these actions are secure and irreversible, removing
 
 # Getting Started
 Apechain is already integrated with Espresso, so getting started is very easy!
-If you want to **read from Espresso finality in an existing application**, learn [how to read from the Espresso Network](https://docs.espressosys.com/network/concepts/read-from-network).
-If you want to create a cross-chain application from scratch, take a look at the [tutorials that we have available](https://docs.espressosys.com/network/guides/dapp).
+If you want to **read from Espresso finality in an existing application**, learn [how to read from the Espresso Network](https://docs.espressosys.com/network/developer/espresso-api/state-api).
+If you want to create a cross-chain application from scratch, take a look at the [Espresso quickstart](https://docs.espressosys.com/network/learn/quickstart).
 

--- a/pages/onboarding.mdx
+++ b/pages/onboarding.mdx
@@ -36,11 +36,11 @@ The [Embedded Wallet](https://docs.sequence.xyz/sdk/headless-wallet/quickstart) 
 - Fully non-custodial, smart contract wallet.
 - Out of the box login with [Web SDK](https://docs.sequence.xyz/sdk/web/overview) or build your own flow.
 
-On the other hand, the [Ecosystem Wallet](https://docs.sequence.xyz/solutions/wallets/ecosystem/overview) caters to apps who want to build an entire ecosystem and connect their users to third-party applications such as external marketplaces or DEX's.
+On the other hand, the [Ecosystem Wallet](https://docs.sequence.xyz/solutions/wallets/ecosystems/overview) caters to apps who want to build an entire ecosystem and connect their users to third-party applications such as external marketplaces or DEX's.
 
 Our [Web SDK](https://docs.sequence.xyz/sdk/web/overview) library is a customizable UI written in Typescript, tailored for a browser experience. This is great when you want to support users with existing wallets like Metamask, have an out-of-the-box experience, as well as millions of potential new users who prefer the convenience of social login.
 
-Lastly, we provide [Wallet Linking](https://docs.sequence.xyz/sdk/web/getting-started) for your ecosystem which enables the ability for a developer to create a verifiable association between two wallets from a single user. Generally, this is a link between an embedded wallet for a game or application and an external wallet, such as Metamask so you can easily query all wallets associated with a single user - across games, ecosystems, and blockchains.
+Lastly, we provide [Wallet Linking](https://docs.sequence.xyz/solutions/wallets/developers/embedded-wallet/wallet-linking) for your ecosystem which enables the ability for a developer to create a verifiable association between two wallets from a single user. Generally, this is a link between an embedded wallet for a game or application and an external wallet, such as Metamask so you can easily query all wallets associated with a single user - across games, ecosystems, and blockchains.
 
 ## Reown (prev. known as WalletConnect)
 


### PR DESCRIPTION
All four URLs return 404. Replacements were checked and return 200.

Sequence, in onboarding.mdx. These are exact equivalents:

  solutions/wallets/ecosystem/overview
    -> solutions/wallets/ecosystems/overview
  A single missing character; the section is named ecosystems.

  sdk/web/getting-started
    -> solutions/wallets/developers/embedded-wallet/wallet-linking
  The link text is Wallet Linking but it pointed at a getting-started
  page, so this also corrects the target, not just the URL.

Espresso, in cross-chain.mdx. These are best-guess mappings, not exact equivalents, because the concepts/ and guides/ sections no longer exist:

  network/concepts/read-from-network
    -> network/developer/espresso-api/state-api
  Closest current page for reading finalized consensus state.

  network/guides/dapp
    -> network/learn/quickstart
  Closest current entry point for building on Espresso. Link text changed
  from tutorials that we have available to Espresso quickstart to match
  what the page actually is. network/developer/rollup-developers is an
  alternative if you would rather point at the integration guide.

Happy to change the two Espresso targets to whatever you prefer.

Separately, and not touched here: ai-agents.mdx links Ape Agent at flowai.xyz/agent/apecoin, which also 404s, and flowai.xyz no longer mentions an Ape Agent anywhere. That looks like a product that has gone away rather than a moved link, so it needs a content decision rather than a URL swap.