### PR TITLE
Fix dead feedback form link and Feeback typo

### DIFF
--- a/pages/feedback.mdx
+++ b/pages/feedback.mdx
@@ -4,7 +4,7 @@ import { Card } from 'nextra/components'
 
 ## Feedback
 
-We're continuously striving to enhance our documentation with feedback from the community. Please share your thoughts using the form below, so we can work together to create the most helpful resources.
+We're continuously striving to enhance our documentation with feedback from the community. Please share your thoughts using the link below, so we can work together to create the most helpful resources.
 
 <br></br>
 
@@ -12,10 +12,10 @@ We're continuously striving to enhance our documentation with feedback from the 
   title={
     <>
      
-      Feeback Form{' '}
+      Feedback Form{' '}
     </>
   }
   target="_blank"
- href="https://3yc4prw48cq.typeform.com/apechaindocs"
+ href="https://github.com/ape-foundation/apechaindocs/issues/new?labels=feedback"
   arrow
 />


### PR DESCRIPTION
The feedback page links to a Typeform that no longer exists:

  https://3yc4prw48cq.typeform.com/apechaindocs

It does not 404. It returns 301 to
typeform.com/explore?...utm_content=typeform-incorrectURL..., which is where Typeform sends deleted or unpublished forms, so anyone clicking Feedback Form lands on Typeform's marketing page instead. Because the final response is a 200, automated link checkers do not catch it.

This points the card at the GitHub issue flow the site already uses. theme.config.tsx already defines a per-page feedback link that opens issues/new with a feedback label, so this makes the dedicated feedback page consistent with that rather than introducing a new mechanism.

Also fixes the card title, which read Feeback Form.

If you would rather re-create the Typeform, so that people without a GitHub account can still send feedback, then only the typo fix here is needed and I am happy to drop the href change.