### PR TITLE
Remove references to the dissolved ApeCoin DAO

### DIFF
--- a/pages/architecture.mdx
+++ b/pages/architecture.mdx
@@ -32,9 +32,7 @@ ApeChain's proof system works Optimistically, which means that it assumes that a
 
 ApeChain utilizes a Security Council to address critical risks associated with the ApeChain protocol and its ecosystem. 
 
-The ApeCoin DAO will soon administer Security Council elections, so that the APE community can democratically determine who will be responsible for being vigilant about the security and integrity of the ApeChain protocol.
-
-While this process is being established by the ApeCoin DAO, an interim Security Council has been established, currently consisting of a small group of Ape Foundation and infrastructure partner signers.
+An interim Security Council has been established, currently consisting of a small group of Ape Foundation and infrastructure partner signers.
 
 
 ## Further Reading


### PR DESCRIPTION
The Security Council section says the ApeCoin DAO will soon administer Security Council elections, and that the process is being established by the ApeCoin DAO. The ApeCoin DAO was dissolved in 2025, so both statements describe a governance process that will not happen as written.

This removes only the two claims that are no longer true, and leaves the verifiable part in place: that an interim Security Council exists, consisting of Ape Foundation and infrastructure partner signers.

I have not tried to describe the current governance arrangement, since I have no authoritative source for it. Happy to adjust to whatever wording the Foundation prefers.