### PR TITLE
Use ApeScan as the block explorer in MetaMask setup

### DIFF
--- a/pages/metamask.mdx
+++ b/pages/metamask.mdx
@@ -25,7 +25,7 @@ You can add the network with the following details:
 | RPC URL        |   https://apechain.calderachain.xyz/http |
 | Chain ID    |    33139   |   
 | Currency Symbol|         APE    |
-| Block Explorer| https://apechain.calderaexplorer.xyz/|
+| Block Explorer| https://apescan.io/|
 <br></br>
 <hr></hr>
 | Testnet      | Details|    
@@ -34,6 +34,6 @@ You can add the network with the following details:
 | RPC URL        |    https://curtis.rpc.caldera.xyz/http   |
 | Chain ID    |    33111   |   
 | Currency Symbol|         APE    |
-| Block Explorer| https://curtis.explorer.caldera.xyz/ |
+| Block Explorer| https://curtis.apescan.io/ |
 
 


### PR DESCRIPTION
block-explorers.mdx describes ApeScan as the primary block explorer for ApeChain and lists curtis.apescan.io for the testnet, but the MetaMask setup page configures users with the Caldera explorer instead.

MetaMask uses the Block Explorer field for every view on explorer link a user follows from their wallet, so this points those at the explorer the docs call primary.

Both explorers are reachable, so this is a consistency change rather than a broken link. RPC URLs are left as they are, since both documented endpoints return chain 33139.