### PR TITLE
Remove outdated Glyph React 19 / Next.js 15 warning

### DIFF
--- a/pages/onboarding.mdx
+++ b/pages/onboarding.mdx
@@ -1,5 +1,3 @@
-import { Callout } from 'nextra/components'
-
 # User Onboarding
 
 ## Glyph
@@ -20,8 +18,6 @@ It enables easy onboarding, transactions, and account management without complex
 It offers a plug-and-play widget that ensures seamless integration into apps, driving adoption on ApeChain.
 
 **Learn more at [Glyph Docs](https://docs.useglyph.io/overview/) or try out the demo: [Glyph Demo](https://demo.useglyph.io/native-integration/)**
-
-<Callout type="warning"> React 19 or Next.js 15 is not supported yet. </Callout>
 
 #### Using Glyph with thirdweb
 Glyph is powered by Privy. That means thirdweb devs can use Glyph as the wallet provider just as they would use Privy. Here's the [walkthrough](https://solutions.thirdweb.com/products/how-to-use-thirdweb-with-privy)


### PR DESCRIPTION
The onboarding page warns that React 19 and Next.js 15 are not supported by Glyph. Both are supported now:

- Glyph's own requirements list React 18 or 19, React DOM 18 or 19, and Next.js 14 or 15.
- yuga-labs/glyph-sdk-react declares peerDependencies of ^18.x || ^19.x for react and react-dom.

The warning now tells developers to avoid versions that work, so it is removed. It was the only Callout on the page, so the nextra Callout import goes with it.