### PR TITLE
docs: add OpenChainBench live RPC benchmark

### DIFF
--- a/pages/node-providers.mdx
+++ b/pages/node-providers.mdx
@@ -28,3 +28,9 @@ import { Callout } from 'nextra/components'
 [Tenderly](https://tenderly.co/) supports ApeChain by providing managed RPC nodes, transaction simulation tools, and monitoring services. Developers can deploy nodes, simulate transactions, and test their dApps efficiently on ApeChain using Tenderly's platform, ensuring smooth operation and faster development​.
 For further exploration on integrations, explore further [here](https://docs.tenderly.co/node/rpc-reference/apechain).
 
+## OpenChainBench
+
+[OpenChainBench](https://openchainbench.com/benchmarks/apechain-rpc) independently measures ApeChain RPC providers on latency (p50, p99) and success rates from three global regions (US East, EU West, Singapore). The live benchmark updates every 60 seconds and shows which provider is fastest for your users' location.
+
+- [ApeChain RPC benchmark](https://openchainbench.com/benchmarks/apechain-rpc)
+


### PR DESCRIPTION
Adds a reference to [OpenChainBench](https://openchainbench.com/benchmarks/apechain-rpc), which independently tracks ApeChain RPC providers on latency (p50, p99) and success rates from 3 global regions, updated every 60 seconds.

Useful for developers comparing the providers listed on this page.